### PR TITLE
fix: multicluster admission webhooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+*.secrets
 
 vendor/
 

--- a/cmd/apiserver/app/config.go
+++ b/cmd/apiserver/app/config.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kplane-dev/apiserver/cmd/apiserver/app/options"
 	mc "github.com/kplane-dev/apiserver/pkg/multicluster"
 	mca "github.com/kplane-dev/apiserver/pkg/multicluster/admission"
+	mcwh "github.com/kplane-dev/apiserver/pkg/multicluster/admission/webhook"
 )
 
 type Config struct {
@@ -83,6 +84,15 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 		Options: opts,
 	}
 
+	// We provide cluster-aware webhook admission below; disable upstream single-cluster webhooks.
+	if opts.Admission != nil && opts.Admission.GenericAdmission != nil {
+		opts.Admission.GenericAdmission.DisablePlugins = append(
+			opts.Admission.GenericAdmission.DisablePlugins,
+			"MutatingAdmissionWebhook",
+			"ValidatingAdmissionWebhook",
+		)
+	}
+
 	genericConfig, versionedInformers, storageFactory, err := controlplaneapiserver.BuildGenericConfig(
 		opts.CompletedOptions,
 		[]*runtime.Scheme{legacyscheme.Scheme, apiextensionsapiserver.Scheme, aggregatorscheme.Scheme},
@@ -124,16 +134,35 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 		return nil, err
 	}
 	c.KubeAPIs = kubeAPIs
+
+	// Cluster-aware webhook admission (per-cluster clients + informers, no global cross-cluster view).
+	authWrapper := webhook.NewDefaultAuthenticationInfoResolverWrapper(
+		kubeAPIs.ControlPlane.ProxyTransport,
+		kubeAPIs.ControlPlane.Generic.EgressSelector,
+		kubeAPIs.ControlPlane.Generic.LoopbackClientConfig,
+		kubeAPIs.ControlPlane.Generic.TracerProvider,
+	)
+	mcWebhookMgr := mcwh.NewManager(mcwh.Options{
+		BaseLoopbackClientConfig: kubeAPIs.ControlPlane.Generic.LoopbackClientConfig,
+		AuthWrapper:              authWrapper,
+		EnableAggregatorRouting:  opts.EnableAggregatorRouting,
+		Hostname:                 kubeAPIs.ControlPlane.Generic.LoopbackClientConfig.Host,
+		PathPrefix:               mcOpts.PathPrefix,
+		ControlPlaneSegment:      mcOpts.ControlPlaneSegment,
+	})
+	mcMutatingWebhook := mcwh.NewMutating(mcOpts, mcWebhookMgr)
+	mcValidatingWebhook := mcwh.NewValidating(mcOpts, mcWebhookMgr)
+
 	// Reinstall admission chain on concrete generics to avoid later overrides
 	{
 		mut := mca.NewMutating(mcOpts)
 		val := mca.NewValidating(mcOpts)
 		base := c.KubeAPIs.ControlPlane.Generic.AdmissionControl
-		chain := []admission.Interface{mut}
+		chain := []admission.Interface{mut, mcMutatingWebhook}
 		if base != nil {
 			chain = append(chain, base)
 		}
-		chain = append(chain, val)
+		chain = append(chain, mcValidatingWebhook, val)
 		c.KubeAPIs.ControlPlane.Generic.AdmissionControl = admission.NewChainHandler(chain...)
 	}
 
@@ -152,11 +181,11 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 		mut := mca.NewMutating(mcOpts)
 		val := mca.NewValidating(mcOpts)
 		base := apiExtensions.GenericConfig.AdmissionControl
-		chain := []admission.Interface{mut}
+		chain := []admission.Interface{mut, mcMutatingWebhook}
 		if base != nil {
 			chain = append(chain, base)
 		}
-		chain = append(chain, val)
+		chain = append(chain, mcValidatingWebhook, val)
 		apiExtensions.GenericConfig.AdmissionControl = admission.NewChainHandler(chain...)
 	}
 	c.ApiExtensions = apiExtensions
@@ -175,11 +204,11 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 		mut := mca.NewMutating(mcOpts)
 		val := mca.NewValidating(mcOpts)
 		base := aggregator.GenericConfig.AdmissionControl
-		chain := []admission.Interface{mut}
+		chain := []admission.Interface{mut, mcMutatingWebhook}
 		if base != nil {
 			chain = append(chain, base)
 		}
-		chain = append(chain, val)
+		chain = append(chain, mcValidatingWebhook, val)
 		aggregator.GenericConfig.AdmissionControl = admission.NewChainHandler(chain...)
 	}
 	c.Aggregator = aggregator

--- a/pkg/multicluster/admission/webhook/manager.go
+++ b/pkg/multicluster/admission/webhook/manager.go
@@ -1,0 +1,158 @@
+package webhook
+
+import (
+	"net/url"
+	"reflect"
+	"strings"
+	"sync"
+
+	webhookutil "k8s.io/apiserver/pkg/util/webhook"
+	clientgoinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type Options struct {
+	// BaseLoopbackClientConfig is the apiserver loopback config for the *root* server.
+	// We will clone it and rewrite Host to include the cluster path prefix.
+	BaseLoopbackClientConfig *rest.Config
+
+	// AuthWrapper is used by upstream webhook plugin to build transport + dialer config.
+	AuthWrapper webhookutil.AuthenticationInfoResolverWrapper
+
+	// EnableAggregatorRouting chooses endpoint-slice resolver vs ClusterIP resolver,
+	// mirroring kube-apiserver behavior.
+	EnableAggregatorRouting bool
+
+	// Hostname is used for loopback service resolution (kubernetes.default.svc).
+	Hostname string
+
+	// PathPrefix and ControlPlaneSegment define the cluster URL form.
+	PathPrefix          string
+	ControlPlaneSegment string
+}
+
+type Manager struct {
+	opts Options
+
+	mu       sync.Mutex
+	clusters map[string]*clusterEnv
+}
+
+type clusterEnv struct {
+	cid string
+
+	stopCh chan struct{}
+	synced chan struct{}
+
+	okMu sync.Mutex
+	ok   bool
+
+	clientset kubernetes.Interface
+	informers clientgoinformers.SharedInformerFactory
+
+	serviceResolver webhookutil.ServiceResolver
+}
+
+func NewManager(opts Options) *Manager {
+	return &Manager{
+		opts:     opts,
+		clusters: map[string]*clusterEnv{},
+	}
+}
+
+func (m *Manager) envForCluster(clusterID string) (*clusterEnv, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if e, ok := m.clusters[clusterID]; ok {
+		return e, nil
+	}
+
+	cfg := rest.CopyConfig(m.opts.BaseLoopbackClientConfig)
+	host, err := withClusterPrefix(cfg.Host, m.opts.PathPrefix, clusterID, m.opts.ControlPlaneSegment)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Host = host
+
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	inf := clientgoinformers.NewSharedInformerFactory(cs, 0)
+
+	sr := newDirectServiceResolver(cs, m.opts.EnableAggregatorRouting, m.opts.Hostname)
+
+	e := &clusterEnv{
+		cid:             clusterID,
+		stopCh:          make(chan struct{}),
+		synced:          make(chan struct{}),
+		clientset:       cs,
+		informers:       inf,
+		serviceResolver: sr,
+	}
+
+	// Warm required informers (must happen before Start()).
+	_ = inf.Core().V1().Namespaces().Informer()
+	_ = inf.Core().V1().Services().Informer()
+	_ = inf.Discovery().V1().EndpointSlices().Informer()
+	_ = inf.Admissionregistration().V1().MutatingWebhookConfigurations().Informer()
+	_ = inf.Admissionregistration().V1().ValidatingWebhookConfigurations().Informer()
+
+	// Start informers for resources needed by webhook admission.
+	inf.Start(e.stopCh)
+
+	go func() {
+		ok := inf.WaitForCacheSync(e.stopCh)
+		e.okMu.Lock()
+		e.ok = allSynced(ok)
+		e.okMu.Unlock()
+		close(e.synced)
+	}()
+
+	m.clusters[clusterID] = e
+	return e, nil
+}
+
+func allSynced(m map[reflect.Type]bool) bool {
+	for _, v := range m {
+		if !v {
+			return false
+		}
+	}
+	return true
+}
+
+func withClusterPrefix(host, pathPrefix, clusterID, controlPlaneSegment string) (string, error) {
+	u, err := url.Parse(host)
+	if err != nil {
+		return "", err
+	}
+	pp := pathPrefix
+	if pp == "" {
+		pp = "/clusters/"
+	}
+	seg := controlPlaneSegment
+	if seg == "" {
+		seg = "control-plane"
+	}
+	// ensure pp ends with "/"
+	if !strings.HasSuffix(pp, "/") {
+		pp = pp + "/"
+	}
+	// join onto existing path
+	basePath := strings.TrimRight(u.Path, "/")
+	u.Path = basePath + pp + clusterID + "/" + seg
+	return u.String(), nil
+}
+
+// StopCluster is test-oriented cleanup; production can leave informers running.
+func (m *Manager) StopCluster(clusterID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if e, ok := m.clusters[clusterID]; ok && e.stopCh != nil {
+		close(e.stopCh)
+		delete(m.clusters, clusterID)
+	}
+}

--- a/pkg/multicluster/admission/webhook/plugins.go
+++ b/pkg/multicluster/admission/webhook/plugins.go
@@ -1,0 +1,185 @@
+package webhook
+
+import (
+	"context"
+	"io"
+	"sync"
+	"time"
+
+	mc "github.com/kplane-dev/apiserver/pkg/multicluster"
+
+	"k8s.io/apiserver/pkg/admission"
+	upstreammutating "k8s.io/apiserver/pkg/admission/plugin/webhook/mutating"
+	upstreamvalidating "k8s.io/apiserver/pkg/admission/plugin/webhook/validating"
+)
+
+// MutatingPlugin dispatches upstream MutatingAdmissionWebhook per cluster.
+type MutatingPlugin struct {
+	*admission.Handler
+	opts mc.Options
+	mgr  *Manager
+
+	mu    sync.Mutex
+	cache map[string]mutatingEntry
+}
+
+// ValidatingPlugin dispatches upstream ValidatingAdmissionWebhook per cluster.
+type ValidatingPlugin struct {
+	*admission.Handler
+	opts mc.Options
+	mgr  *Manager
+
+	mu    sync.Mutex
+	cache map[string]validatingEntry
+}
+
+type mutatingEntry struct {
+	env    *clusterEnv
+	plugin *upstreammutating.Plugin
+}
+
+type validatingEntry struct {
+	env    *clusterEnv
+	plugin *upstreamvalidating.Plugin
+}
+
+func NewMutating(opts mc.Options, mgr *Manager) *MutatingPlugin {
+	return &MutatingPlugin{
+		Handler: admission.NewHandler(admission.Connect, admission.Create, admission.Delete, admission.Update),
+		opts:    opts,
+		mgr:     mgr,
+		cache:   map[string]mutatingEntry{},
+	}
+}
+
+func NewValidating(opts mc.Options, mgr *Manager) *ValidatingPlugin {
+	return &ValidatingPlugin{
+		Handler: admission.NewHandler(admission.Connect, admission.Create, admission.Delete, admission.Update),
+		opts:    opts,
+		mgr:     mgr,
+		cache:   map[string]validatingEntry{},
+	}
+}
+
+func (p *MutatingPlugin) Admit(ctx context.Context, attr admission.Attributes, o admission.ObjectInterfaces) error {
+	env, plugin := p.forCluster(ctx)
+	waitForWebhookCaches(ctx, attr, env)
+	return plugin.Admit(ctx, attr, o)
+}
+
+func (p *ValidatingPlugin) Validate(ctx context.Context, attr admission.Attributes, o admission.ObjectInterfaces) error {
+	env, plugin := p.forCluster(ctx)
+	waitForWebhookCaches(ctx, attr, env)
+	return plugin.Validate(ctx, attr, o)
+}
+
+func (p *MutatingPlugin) forCluster(ctx context.Context) (*clusterEnv, *upstreammutating.Plugin) {
+	cid, _, _ := mc.FromContext(ctx)
+	if cid == "" {
+		cid = p.opts.DefaultCluster
+	}
+	if cid == "" {
+		cid = mc.DefaultClusterName
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if existing, ok := p.cache[cid]; ok {
+		return existing.env, existing.plugin
+	}
+
+	env, err := p.mgr.envForCluster(cid)
+	if err != nil {
+		// Admission interface doesn't allow returning init error cleanly here;
+		// panic is acceptable since this indicates server misconfiguration.
+		panic(err)
+	}
+
+	plugin, err := upstreammutating.NewMutatingWebhook(io.Reader(nil))
+	if err != nil {
+		panic(err)
+	}
+	plugin.SetExternalKubeClientSet(env.clientset)
+	plugin.SetExternalKubeInformerFactory(env.informers)
+	plugin.SetServiceResolver(env.serviceResolver)
+	plugin.SetAuthenticationInfoResolverWrapper(p.mgr.opts.AuthWrapper)
+	// Never gate apiserver readiness on these per-cluster informers.
+	plugin.SetReadyFunc(func() bool { return true })
+	if err := plugin.ValidateInitialization(); err != nil {
+		panic(err)
+	}
+
+	p.cache[cid] = mutatingEntry{env: env, plugin: plugin}
+	return env, plugin
+}
+
+func (p *ValidatingPlugin) forCluster(ctx context.Context) (*clusterEnv, *upstreamvalidating.Plugin) {
+	cid, _, _ := mc.FromContext(ctx)
+	if cid == "" {
+		cid = p.opts.DefaultCluster
+	}
+	if cid == "" {
+		cid = mc.DefaultClusterName
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if existing, ok := p.cache[cid]; ok {
+		return existing.env, existing.plugin
+	}
+
+	env, err := p.mgr.envForCluster(cid)
+	if err != nil {
+		panic(err)
+	}
+
+	plugin, err := upstreamvalidating.NewValidatingAdmissionWebhook(io.Reader(nil))
+	if err != nil {
+		panic(err)
+	}
+	plugin.SetExternalKubeClientSet(env.clientset)
+	plugin.SetExternalKubeInformerFactory(env.informers)
+	plugin.SetServiceResolver(env.serviceResolver)
+	plugin.SetAuthenticationInfoResolverWrapper(p.mgr.opts.AuthWrapper)
+	// Never gate apiserver readiness on these per-cluster informers.
+	plugin.SetReadyFunc(func() bool { return true })
+	if err := plugin.ValidateInitialization(); err != nil {
+		panic(err)
+	}
+
+	p.cache[cid] = validatingEntry{env: env, plugin: plugin}
+	return env, plugin
+}
+
+func waitForWebhookCaches(ctx context.Context, attr admission.Attributes, env *clusterEnv) {
+	if env == nil {
+		return
+	}
+	// Avoid impacting control plane startup/leader-election, etc.
+	if attr.GetNamespace() == "kube-system" && attr.GetResource().Resource == "leases" {
+		return
+	}
+	// If caches are already synced, we're good.
+	select {
+	case <-env.synced:
+		return
+	default:
+	}
+
+	// Wait briefly for informer initial list+watch to complete so webhook config + services are visible.
+	// Fail-open if it doesn't happen quickly (prevents deadlocks during early startup).
+	timeout := 10 * time.Second
+	if dl, ok := ctx.Deadline(); ok {
+		rem := time.Until(dl)
+		if rem > 0 && rem < timeout {
+			timeout = rem
+		}
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-env.synced:
+	case <-timer.C:
+	case <-ctx.Done():
+	}
+}

--- a/pkg/multicluster/admission/webhook/resolver.go
+++ b/pkg/multicluster/admission/webhook/resolver.go
@@ -1,0 +1,128 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+)
+
+type directServiceResolver struct {
+	cs                    kubernetes.Interface
+	enableEndpointRouting bool
+	hostname              string
+}
+
+func newDirectServiceResolver(cs kubernetes.Interface, enableEndpointRouting bool, hostname string) *directServiceResolver {
+	return &directServiceResolver{
+		cs:                    cs,
+		enableEndpointRouting: enableEndpointRouting,
+		hostname:              hostname,
+	}
+}
+
+func (r *directServiceResolver) ResolveEndpoint(namespace, name string, port int32) (*url.URL, error) {
+	if len(name) == 0 || len(namespace) == 0 || port == 0 {
+		return nil, fmt.Errorf("cannot resolve an empty service name or namespace or port")
+	}
+
+	// resolve kubernetes.default.svc locally
+	if name == "kubernetes" && namespace == corev1.NamespaceDefault && port == 443 {
+		if u, err := url.Parse(r.hostname); err == nil {
+			return u, nil
+		}
+	}
+
+	ctx := context.Background()
+	svc, err := r.cs.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	if !r.enableEndpointRouting {
+		ip := svc.Spec.ClusterIP
+		if ip == "" || ip == "None" {
+			return nil, fmt.Errorf("service %q has no ClusterIP", name)
+		}
+		return &url.URL{Scheme: "https", Host: net.JoinHostPort(ip, strconv.Itoa(int(port)))}, nil
+	}
+
+	targetName, targetPort := serviceTargetPort(svc, port)
+
+	selector := labels.Set{discoveryv1.LabelServiceName: name}.AsSelector().String()
+	slices, err := r.cs.DiscoveryV1().EndpointSlices(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, err
+	}
+	if len(slices.Items) == 0 {
+		return nil, fmt.Errorf("no endpointslices found for service %q", name)
+	}
+
+	epPort := port
+	if targetPort != 0 {
+		epPort = targetPort
+	} else if targetName != "" {
+		found := false
+		for i := range slices.Items {
+			for _, p := range slices.Items[i].Ports {
+				if p.Name != nil && *p.Name == targetName && p.Port != nil {
+					epPort = *p.Port
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+	}
+
+	addr, err := firstEndpointAddress(slices.Items)
+	if err != nil {
+		return nil, err
+	}
+
+	return &url.URL{Scheme: "https", Host: net.JoinHostPort(addr, strconv.Itoa(int(epPort)))}, nil
+}
+
+func serviceTargetPort(svc *corev1.Service, servicePort int32) (targetName string, targetPort int32) {
+	for _, sp := range svc.Spec.Ports {
+		if sp.Port != servicePort {
+			continue
+		}
+		if sp.TargetPort.Type == 1 /* String */ {
+			return sp.TargetPort.StrVal, 0
+		}
+		if sp.TargetPort.IntVal != 0 {
+			return "", int32(sp.TargetPort.IntVal)
+		}
+		return "", servicePort
+	}
+	return "", servicePort
+}
+
+func firstEndpointAddress(slices []discoveryv1.EndpointSlice) (string, error) {
+	for i := range slices {
+		for _, ep := range slices[i].Endpoints {
+			ready := true
+			if ep.Conditions.Ready != nil {
+				ready = *ep.Conditions.Ready
+			}
+			if !ready {
+				continue
+			}
+			if len(ep.Addresses) == 0 {
+				continue
+			}
+			return ep.Addresses[0], nil
+		}
+	}
+	return "", fmt.Errorf("no ready endpoint addresses found")
+}

--- a/test/smoke/apiserver_test.go
+++ b/test/smoke/apiserver_test.go
@@ -1,0 +1,268 @@
+package smoke
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type testAPIServer struct {
+	t       *testing.T
+	binPath string
+	port    int
+	tmpDir  string
+
+	cmd    *exec.Cmd
+	cancel context.CancelFunc
+
+	logMu sync.Mutex
+	log   strings.Builder
+}
+
+func mustFreePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func buildAPIServerBinary(t *testing.T) string {
+	t.Helper()
+
+	tmp := t.TempDir()
+	out := filepath.Join(tmp, "apiserver.testbin")
+	cmd := exec.Command("go", "build", "-o", out, "./cmd/apiserver")
+	cmd.Env = os.Environ()
+	cmd.Dir = repoRoot(t)
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to build apiserver: %v\n%s", err, string(b))
+	}
+	return out
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := wd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find go.mod from %s", wd)
+		}
+		dir = parent
+	}
+}
+
+func mustWriteRSAKey(t *testing.T, path string) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return path
+}
+
+func mustWriteTokenFile(t *testing.T, path string) string {
+	t.Helper()
+	const token = "smoketoken"
+	line := fmt.Sprintf("%s,admin,admin,system:masters\n", token)
+	if err := os.WriteFile(path, []byte(line), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	return path
+}
+
+func startAPIServer(t *testing.T, etcdEndpoints string) *testAPIServer {
+	t.Helper()
+	if strings.TrimSpace(etcdEndpoints) == "" {
+		t.Skip("ETCD_ENDPOINTS is not set; skipping integration smoke tests")
+	}
+
+	bin := buildAPIServerBinary(t)
+	port := mustFreePort(t)
+	tmp := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &testAPIServer{
+		t:       t,
+		binPath: bin,
+		port:    port,
+		tmpDir:  tmp,
+		cancel:  cancel,
+	}
+
+	args := []string{
+		"--etcd-servers=" + etcdEndpoints,
+		"--cert-dir=" + filepath.Join(tmp, "certs"),
+		"--secure-port=" + fmt.Sprintf("%d", port),
+		"--enable-aggregator-routing=true",
+		"--authorization-mode=RBAC",
+		"--anonymous-auth=true",
+		"--token-auth-file=" + mustWriteTokenFile(t, filepath.Join(tmp, "tokens.csv")),
+		"--allow-privileged=true",
+		"--service-cluster-ip-range=10.0.0.0/24",
+		"--service-account-issuer=test",
+		"--service-account-signing-key-file=" + mustWriteRSAKey(t, filepath.Join(tmp, "sa.key")),
+		"--service-account-key-file=" + filepath.Join(tmp, "sa.key"),
+		// reduce noise + make startup faster for tests
+		"--v=2",
+	}
+
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Env = os.Environ()
+	// keep stdout/stderr for debugging; buffer in-memory too
+	stdout, _ := cmd.StdoutPipe()
+	stderr, _ := cmd.StderrPipe()
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start apiserver: %v", err)
+	}
+	s.cmd = cmd
+
+	// Best-effort log capture
+	go s.capture("stdout", stdout)
+	go s.capture("stderr", stderr)
+
+	t.Cleanup(func() {
+		s.Stop()
+	})
+
+	// Wait for readiness on root cluster
+	s.waitReady(t, "root")
+
+	return s
+}
+
+func (s *testAPIServer) capture(stream string, r io.ReadCloser) {
+	defer r.Close()
+	sc := bufio.NewScanner(r)
+	// allow long log lines
+	buf := make([]byte, 0, 64*1024)
+	sc.Buffer(buf, 2*1024*1024)
+
+	s.logMu.Lock()
+	s.log.WriteString("\n--- " + stream + " ---\n")
+	s.logMu.Unlock()
+
+	for sc.Scan() {
+		s.logMu.Lock()
+		s.log.WriteString(sc.Text())
+		s.log.WriteString("\n")
+		s.logMu.Unlock()
+	}
+}
+
+func (s *testAPIServer) baseURL() string {
+	return fmt.Sprintf("https://127.0.0.1:%d", s.port)
+}
+
+func (s *testAPIServer) clusterURL(clusterID string) string {
+	return fmt.Sprintf("%s/clusters/%s/control-plane", s.baseURL(), clusterID)
+}
+
+func (s *testAPIServer) waitReady(t *testing.T, clusterID string) {
+	t.Helper()
+
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // test only
+		},
+	}
+
+	url := s.clusterURL(clusterID) + "/readyz"
+	deadline := time.Now().Add(60 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+		req.Header.Set("Authorization", "Bearer smoketoken")
+		resp, err := client.Do(req)
+		if err == nil && resp != nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == 200 {
+				return
+			}
+			err = fmt.Errorf("readyz status=%d", resp.StatusCode)
+		}
+		lastErr = err
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	s.t.Fatalf("apiserver never became ready: %v\nlogs:\n%s", lastErr, s.logs())
+}
+
+func (s *testAPIServer) logs() string {
+	s.logMu.Lock()
+	defer s.logMu.Unlock()
+	return s.log.String()
+}
+
+func (s *testAPIServer) Stop() {
+	if s == nil {
+		return
+	}
+	if s.cancel != nil {
+		s.cancel()
+	}
+	if s.cmd == nil || s.cmd.Process == nil {
+		return
+	}
+
+	// Try graceful first.
+	_ = s.cmd.Process.Signal(syscall.SIGTERM)
+
+	done := make(chan error, 1)
+	go func() { done <- s.cmd.Wait() }()
+
+	select {
+	case <-time.After(5 * time.Second):
+		_ = s.cmd.Process.Kill()
+		<-done
+	case <-done:
+	}
+}
+
+func isConnRefused(err error) bool {
+	if err == nil {
+		return false
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+	return strings.Contains(err.Error(), "connection refused")
+}

--- a/test/smoke/client_test.go
+++ b/test/smoke/client_test.go
@@ -1,0 +1,49 @@
+package smoke
+
+import (
+	"crypto/tls"
+	"net/http"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func kubeConfigForCluster(base string) *rest.Config {
+	// rest.Config.Host can include a path prefix; client-go will append /api, /apis, etc.
+	return &rest.Config{
+		Host:        base,
+		BearerToken: "smoketoken",
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: true, // test-only, apiserver uses self-signed certs by default
+		},
+		// Make sure the transport doesn't try to use the system proxy in CI/dev boxes.
+		Proxy: http.ProxyFromEnvironment,
+		WrapTransport: func(rt http.RoundTripper) http.RoundTripper {
+			if rt == nil {
+				rt = http.DefaultTransport
+			}
+			if t, ok := rt.(*http.Transport); ok {
+				cp := t.Clone()
+				if cp.TLSClientConfig == nil {
+					cp.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // test-only
+				} else {
+					cp.TLSClientConfig = cp.TLSClientConfig.Clone()
+					cp.TLSClientConfig.InsecureSkipVerify = true //nolint:gosec // test-only
+				}
+				return cp
+			}
+			return rt
+		},
+	}
+}
+
+func kubeClientForCluster(t interface {
+	Fatalf(string, ...any)
+}, s *testAPIServer, clusterID string) *kubernetes.Clientset {
+	cfg := kubeConfigForCluster(s.clusterURL(clusterID))
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("failed to build clientset: %v", err)
+	}
+	return cs
+}

--- a/test/smoke/crud_test.go
+++ b/test/smoke/crud_test.go
@@ -1,0 +1,104 @@
+package smoke
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func randSuffix(nBytes int) string {
+	b := make([]byte, nBytes)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+func TestCRUD_RandomizedAcrossClusters(t *testing.T) {
+	etcd := os.Getenv("ETCD_ENDPOINTS")
+	s := startAPIServer(t, etcd)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	clusters := []string{
+		"root",
+		"c-" + randSuffix(3),
+		"c-" + randSuffix(3),
+	}
+
+	for _, cid := range clusters {
+		cs := kubeClientForCluster(t, s, cid)
+
+		ns := "default"
+		cmName := "cm-" + randSuffix(4)
+		_, err := cs.CoreV1().ConfigMaps(ns).Create(ctx, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: cmName,
+			},
+			Data: map[string]string{"hello": "world"},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("cluster=%s create configmap: %v", cid, err)
+		}
+
+		got, err := cs.CoreV1().ConfigMaps(ns).Get(ctx, cmName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("cluster=%s get configmap: %v", cid, err)
+		}
+		if got.Data["hello"] != "world" {
+			t.Fatalf("cluster=%s got unexpected data: %#v", cid, got.Data)
+		}
+
+		got.Data["hello"] = "there"
+		_, err = cs.CoreV1().ConfigMaps(ns).Update(ctx, got, metav1.UpdateOptions{})
+		if err != nil {
+			t.Fatalf("cluster=%s update configmap: %v", cid, err)
+		}
+
+		got2, err := cs.CoreV1().ConfigMaps(ns).Get(ctx, cmName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("cluster=%s get configmap (after update): %v", cid, err)
+		}
+		if got2.Data["hello"] != "there" {
+			t.Fatalf("cluster=%s got unexpected data after update: %#v", cid, got2.Data)
+		}
+
+		// Delete the configmap
+		err = cs.CoreV1().ConfigMaps(ns).Delete(ctx, cmName, metav1.DeleteOptions{})
+		if err != nil {
+			t.Fatalf("cluster=%s delete configmap: %v", cid, err)
+		}
+	}
+
+	// Isolation check: create in one cluster, ensure not visible in another.
+	if len(clusters) < 2 {
+		return
+	}
+	cA, cB := clusters[1], clusters[2]
+	csA := kubeClientForCluster(t, s, cA)
+	csB := kubeClientForCluster(t, s, cB)
+
+	ns := "default"
+	cmName := "cm-" + randSuffix(4)
+	_, err := csA.CoreV1().ConfigMaps(ns).Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cmName},
+		Data:       map[string]string{"x": "y"},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("cluster=%s create configmap: %v", cA, err)
+	}
+
+	_, err = csB.CoreV1().ConfigMaps(ns).Get(ctx, cmName, metav1.GetOptions{})
+	if err == nil || !apierrors.IsNotFound(err) {
+		t.Fatalf("expected notfound in other cluster (%s), got: %v", cB, err)
+	}
+
+	t.Logf("clusters tested: %s", fmt.Sprintf("%v", clusters))
+}

--- a/test/smoke/webhook_test.go
+++ b/test/smoke/webhook_test.go
@@ -1,0 +1,354 @@
+package smoke
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func newCA(t *testing.T) (caCert *x509.Certificate, caKey *rsa.PrivateKey, caPEM []byte) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("gen ca key: %v", err)
+	}
+	tpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "smoke-ca",
+		},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tpl, tpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create ca cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse ca cert: %v", err)
+	}
+	var b []byte
+	b = append(b, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})...)
+	return cert, key, b
+}
+
+func newServerCert(t *testing.T, caCert *x509.Certificate, caKey *rsa.PrivateKey, host string) tls.Certificate {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("gen server key: %v", err)
+	}
+	serial, _ := rand.Int(rand.Reader, big.NewInt(1<<62))
+	tpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: host,
+		},
+		NotBefore:   time.Now().Add(-1 * time.Hour),
+		NotAfter:    time.Now().Add(24 * time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		tpl.IPAddresses = []net.IP{ip}
+	} else {
+		tpl.DNSNames = []string{host}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tpl, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create server cert: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("keypair: %v", err)
+	}
+	return cert
+}
+
+func startValidatingWebhookServer(t *testing.T, listenHost, certDNS string) (addr string, caBundle []byte, stop func()) {
+	t.Helper()
+
+	caCert, caKey, caPEM := newCA(t)
+	_ = caCert
+	srvCert := newServerCert(t, caCert, caKey, certDNS)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/validate", func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var review admissionv1.AdmissionReview
+		if err := json.NewDecoder(r.Body).Decode(&review); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		resp := admissionv1.AdmissionResponse{
+			UID:     review.Request.UID,
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: "denied by smoke webhook",
+				Reason:  metav1.StatusReasonForbidden,
+				Code:    403,
+			},
+		}
+		out := admissionv1.AdmissionReview{
+			TypeMeta: review.TypeMeta,
+			Response: &resp,
+		}
+		_ = json.NewEncoder(w).Encode(out)
+	})
+
+	ln, err := net.Listen("tcp", net.JoinHostPort(listenHost, "0"))
+	if err != nil {
+		t.Fatalf("listen webhook: %v", err)
+	}
+	srv := &http.Server{
+		Handler: mux,
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{srvCert},
+		},
+	}
+	go func() {
+		_ = srv.ServeTLS(ln, "", "")
+	}()
+
+	stopFn := func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	}
+	return ln.Addr().String(), caPEM, stopFn
+}
+
+func TestWebhook_ServiceBacked_MulticlusterScoping(t *testing.T) {
+	etcd := os.Getenv("ETCD_ENDPOINTS")
+	s := startAPIServer(t, etcd)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	hostIP := firstNonLoopbackIPv4(t)
+
+	// Pick a non-root cluster to validate the suspected bug.
+	clusterA := "c-" + randSuffix(3)
+	clusterB := "c-" + randSuffix(3)
+	root := "root"
+
+	csA := kubeClientForCluster(t, s, clusterA)
+	csB := kubeClientForCluster(t, s, clusterB)
+	csRoot := kubeClientForCluster(t, s, root)
+
+	ns := "default"
+
+	// Service + EndpointSlice that resolves to our local webhook server.
+	svcName := "svc-wh-" + randSuffix(3)
+	serviceDNS := svcName + "." + ns + ".svc"
+
+	whAddr, caBundle, stopWh := startValidatingWebhookServer(t, hostIP, serviceDNS)
+	defer stopWh()
+
+	_, portStr, err := net.SplitHostPort(whAddr)
+	if err != nil {
+		t.Fatalf("split webhook addr: %v", err)
+	}
+	_, err = csA.CoreV1().Services(ns).Create(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: svcName},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Name: "https", Port: 443, TargetPort: intstrFromString("https")}},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("cluster=%s create svc: %v", clusterA, err)
+	}
+
+	esName := "eps-" + randSuffix(3)
+	proto := corev1.ProtocolTCP
+	_, err = csA.DiscoveryV1().EndpointSlices(ns).Create(ctx, &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: esName,
+			Labels: map[string]string{
+				discoveryv1.LabelServiceName: svcName,
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{
+			{Addresses: []string{hostIP}},
+		},
+		Ports: []discoveryv1.EndpointPort{
+			{Name: ptr("https"), Protocol: &proto, Port: ptrInt32(parsePort(t, portStr))},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("cluster=%s create endpointslice: %v", clusterA, err)
+	}
+
+	// ValidatingWebhookConfiguration in clusterA that should deny ConfigMap creates.
+	whName := "vwh-" + randSuffix(3)
+	sideEffects := admissionregv1.SideEffectClassNone
+	failurePolicy := admissionregv1.Fail
+	matchPolicy := admissionregv1.Equivalent
+	timeout := int32(5)
+	scope := admissionregv1.NamespacedScope
+	path := "/validate"
+	port := int32(443)
+
+	_, err = csA.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(ctx, &admissionregv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: whName},
+		Webhooks: []admissionregv1.ValidatingWebhook{
+			{
+				Name: "deny-configmaps.smoke.kplane.dev",
+				ClientConfig: admissionregv1.WebhookClientConfig{
+					Service: &admissionregv1.ServiceReference{
+						Namespace: ns,
+						Name:      svcName,
+						Path:      &path,
+						Port:      &port,
+					},
+					CABundle: caBundle,
+				},
+				Rules: []admissionregv1.RuleWithOperations{
+					{
+						Operations: []admissionregv1.OperationType{admissionregv1.Create},
+						Rule: admissionregv1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"configmaps"},
+							Scope:       &scope,
+						},
+					},
+				},
+				FailurePolicy:           &failurePolicy,
+				MatchPolicy:             &matchPolicy,
+				SideEffects:             &sideEffects,
+				AdmissionReviewVersions: []string{"v1"},
+				TimeoutSeconds:          &timeout,
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("cluster=%s create validatingwebhookconfiguration: %v", clusterA, err)
+	}
+	if list, err := csRoot.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{}); err == nil {
+		t.Logf("root sees %d validatingwebhookconfigurations", len(list.Items))
+	}
+	t.Cleanup(func() {
+		_ = csA.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(context.Background(), whName, metav1.DeleteOptions{})
+	})
+
+	// Allow informers to observe the service/endpoints before admission calls.
+	time.Sleep(2 * time.Second)
+
+	// Isolation assertion: the webhook Service/EndpointSlice should not exist in root.
+	{
+		_, err := csRoot.CoreV1().Services(ns).Get(ctx, svcName, metav1.GetOptions{})
+		if err == nil || !apierrors.IsNotFound(err) {
+			t.Fatalf("expected root to NOT have webhook service %s/%s, got: %v", ns, svcName, err)
+		}
+		slices, err := csRoot.DiscoveryV1().EndpointSlices(ns).List(ctx, metav1.ListOptions{
+			LabelSelector: labels.Set{discoveryv1.LabelServiceName: svcName}.AsSelector().String(),
+		})
+		if err != nil {
+			t.Fatalf("list root endpointslices: %v", err)
+		}
+		if len(slices.Items) != 0 {
+			t.Fatalf("expected root to have 0 endpointslices for service %s/%s, got: %d", ns, svcName, len(slices.Items))
+		}
+	}
+
+	// Try to create a ConfigMap in clusterA; we expect the webhook to deny.
+	_, err = csA.CoreV1().ConfigMaps(ns).Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "cm-deny-" + randSuffix(3)},
+		Data:       map[string]string{"a": "b"},
+	}, metav1.CreateOptions{})
+	if err == nil {
+		t.Fatalf("expected webhook to deny configmap create in cluster=%s, but it succeeded (this indicates the webhook registration/resolution is scoped wrong)", clusterA)
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("expected forbidden from webhook in cluster=%s, got: %v", clusterA, err)
+	}
+
+	// Cross-cluster assertion: clusterB should NOT be affected by clusterA's webhook.
+	_, err = csB.CoreV1().ConfigMaps(ns).Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "cm-allow-" + randSuffix(3)},
+		Data:       map[string]string{"a": "b"},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("expected configmap create to succeed in other cluster (%s), got: %v", clusterB, err)
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func ptrInt32(v int32) *int32 { return &v }
+
+func parsePort(t *testing.T, s string) int32 {
+	t.Helper()
+	var p int
+	_, err := fmt.Sscanf(s, "%d", &p)
+	if err != nil || p <= 0 || p > 65535 {
+		t.Fatalf("bad port %q: %v", s, err)
+	}
+	return int32(p)
+}
+
+func intstrFromString(s string) intstr.IntOrString {
+	return intstr.IntOrString{Type: intstr.String, StrVal: s}
+}
+
+func firstNonLoopbackIPv4(t *testing.T) string {
+	t.Helper()
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Fatalf("list interfaces: %v", err)
+	}
+	for _, iface := range ifaces {
+		if (iface.Flags&net.FlagUp) == 0 || (iface.Flags&net.FlagLoopback) != 0 {
+			continue
+		}
+		addrs, _ := iface.Addrs()
+		for _, a := range addrs {
+			var ip net.IP
+			switch v := a.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+			ip = ip.To4()
+			if ip == nil {
+				continue
+			}
+			return ip.String()
+		}
+	}
+	t.Fatalf("no non-loopback IPv4 address found")
+	return ""
+}


### PR DESCRIPTION
## Summary
- Implement per-cluster webhook admission wrappers with cluster-scoped clients/informers/service resolution.
- Wire new webhook chain and disable upstream webhook plugins in apiserver config.
- Add smoke tests validating service-backed webhook scoping and multicluster CRUD behavior.
- Ignore .secrets files in repo.

## Testing
- go test ./test/smoke -run Webhook -count=1
- go test ./test/smoke -run Crud -count=1"