### PR TITLE
Control plane naming and isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,34 @@ Probe readiness (self-signed TLS; skip verification in curl):
 curl -k https://127.0.0.1:6443/clusters/root/control-plane/readyz
 ```
 
+### Multicluster control planes
+Requests are scoped by path:
+`/clusters/{cluster}/control-plane/...`
+
+The **root control plane** is the default cluster that receives CLI flag
+configuration and is used for default routing when no cluster is specified.
+You can change its name with:
+```bash
+--root-control-plane-name=default
+```
+When changed, the readiness path becomes:
+```
+https://127.0.0.1:6443/clusters/default/control-plane/readyz
+```
+
+#### Webhooks
+Admission webhooks are scoped per control plane. For each cluster, the server
+creates a per-cluster webhook client/informer stack and resolves Services and
+EndpointSlices within that cluster only. This prevents webhook config and
+service discovery from leaking across clusters.
+
+#### Auth (authentication + authorization)
+Authentication and authorization are also per control plane. For each cluster,
+the server constructs authenticators/authorizers using per-cluster loopback
+clients and informers. This isolates RBAC data, service-account tokens, and
+TokenReview/SubjectAccessReview evaluations so clusters can operate alongside
+each other without sharing auth state.
+
 ### Docker image
 Build locally:
 ```bash

--- a/cmd/apiserver/app/config.go
+++ b/cmd/apiserver/app/config.go
@@ -21,6 +21,7 @@ import (
 
 	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/util/webhook"
@@ -36,6 +37,7 @@ import (
 	mc "github.com/kplane-dev/apiserver/pkg/multicluster"
 	mca "github.com/kplane-dev/apiserver/pkg/multicluster/admission"
 	mcwh "github.com/kplane-dev/apiserver/pkg/multicluster/admission/webhook"
+	mcauth "github.com/kplane-dev/apiserver/pkg/multicluster/auth"
 )
 
 type Config struct {
@@ -106,9 +108,30 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 	// Install multicluster request routing early in the handler chain
 	mcOpts := mc.DefaultOptions
 	mcOpts.EtcdPrefix = storageFactory.StorageConfig.Prefix
+	if opts.RootControlPlaneName != "" {
+		mcOpts.DefaultCluster = opts.RootControlPlaneName
+	}
 	genericConfig.BuildHandlerChainFunc = func(h http.Handler, conf *server.Config) http.Handler {
 		ex := mc.PathExtractor{PathPrefix: mcOpts.PathPrefix, ControlPlaneSegment: mcOpts.ControlPlaneSegment}
 		return mc.WithClusterRouting(server.DefaultBuildHandlerChain(h, conf), ex, mcOpts)
+	}
+
+	authManager := mcauth.NewManager(wait.ContextForChannel(genericConfig.DrainedNotify()), mcauth.Options{
+		BaseLoopbackClientConfig: genericConfig.LoopbackClientConfig,
+		PathPrefix:               mcOpts.PathPrefix,
+		ControlPlaneSegment:      mcOpts.ControlPlaneSegment,
+		Authentication:           opts.Authentication,
+		Authorization:            opts.Authorization,
+		EgressSelector:           genericConfig.EgressSelector,
+		APIServerID:              genericConfig.APIServerID,
+	})
+	if genericConfig.Authentication.Authenticator != nil {
+		genericConfig.Authentication.Authenticator = mcauth.NewClusterAuthenticator(mcOpts.DefaultCluster, genericConfig.Authentication.Authenticator, authManager)
+	}
+	if genericConfig.Authorization.Authorizer != nil {
+		clusterAuthorizer := mcauth.NewClusterAuthorizer(mcOpts.DefaultCluster, genericConfig.Authorization.Authorizer, genericConfig.RuleResolver, authManager)
+		genericConfig.Authorization.Authorizer = clusterAuthorizer
+		genericConfig.RuleResolver = clusterAuthorizer
 	}
 
 	// Decorate storage to inject cluster-aware key rewriting and filtering

--- a/cmd/apiserver/app/options/options.go
+++ b/cmd/apiserver/app/options/options.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	mc "github.com/kplane-dev/apiserver/pkg/multicluster"
 	v1 "k8s.io/api/core/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -46,6 +47,7 @@ type Extra struct {
 	AllowPrivileged           bool
 	KubeletConfig             kubeletclient.KubeletClientConfig
 	KubernetesServiceNodePort int
+	RootControlPlaneName      string
 	// ServiceClusterIPRange is mapped to input provided by user
 	ServiceClusterIPRanges string
 	// PrimaryServiceClusterIPRange and SecondaryServiceClusterIPRange are the results
@@ -88,6 +90,7 @@ func NewServerRunOptions() *ServerRunOptions {
 			},
 			ServiceNodePortRange: kubeoptions.DefaultServiceNodePortRange,
 			MasterCount:          1,
+			RootControlPlaneName: mc.DefaultClusterName,
 		},
 	}
 
@@ -102,6 +105,10 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 
 	// Note: the weird ""+ in below lines seems to be the only way to get gofmt to
 	// arrange these text blocks sensibly. Grrr.
+	mcfs := fss.FlagSet("multicluster")
+	mcfs.StringVar(&s.RootControlPlaneName, "root-control-plane-name", s.RootControlPlaneName,
+		"Name of the root control plane that receives CLI flag configuration and is used for default cluster routing.")
+
 	fs := fss.FlagSet("misc")
 
 	fs.BoolVar(&s.AllowPrivileged, "allow-privileged", s.AllowPrivileged,

--- a/cmd/apiserver/app/options/validation.go
+++ b/cmd/apiserver/app/options/validation.go
@@ -108,6 +108,17 @@ func validateServiceNodePort(options Extra) []error {
 	return errs
 }
 
+func validateRootControlPlaneName(name string) []error {
+	var errs []error
+	if strings.TrimSpace(name) == "" {
+		errs = append(errs, fmt.Errorf("--root-control-plane-name must not be empty"))
+	}
+	if strings.Contains(name, "/") {
+		errs = append(errs, fmt.Errorf("--root-control-plane-name must not contain '/'"))
+	}
+	return errs
+}
+
 func validatePublicIPServiceClusterIPRangeIPFamilies(extra Extra, generic genericoptions.ServerRunOptions) []error {
 	// The "kubernetes.default" Service is SingleStack based on the configured ServiceIPRange.
 	// If the bootstrap controller reconcile the kubernetes.default Service and Endpoints, it must
@@ -134,6 +145,7 @@ func (s CompletedOptions) Validate() []error {
 	errs = append(errs, s.CompletedOptions.Validate()...)
 	errs = append(errs, validateClusterIPFlags(s.Extra)...)
 	errs = append(errs, validateServiceNodePort(s.Extra)...)
+	errs = append(errs, validateRootControlPlaneName(s.RootControlPlaneName)...)
 	errs = append(errs, validatePublicIPServiceClusterIPRangeIPFamilies(s.Extra, *s.GenericServerRunOptions)...)
 
 	if s.MasterCount <= 0 {

--- a/pkg/multicluster/admission/webhook/manager.go
+++ b/pkg/multicluster/admission/webhook/manager.go
@@ -1,15 +1,15 @@
 package webhook
 
 import (
-	"net/url"
 	"reflect"
-	"strings"
 	"sync"
 
 	webhookutil "k8s.io/apiserver/pkg/util/webhook"
 	clientgoinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	mc "github.com/kplane-dev/apiserver/pkg/multicluster"
 )
 
 type Options struct {
@@ -70,7 +70,10 @@ func (m *Manager) envForCluster(clusterID string) (*clusterEnv, error) {
 	}
 
 	cfg := rest.CopyConfig(m.opts.BaseLoopbackClientConfig)
-	host, err := withClusterPrefix(cfg.Host, m.opts.PathPrefix, clusterID, m.opts.ControlPlaneSegment)
+	host, err := mc.ClusterHost(cfg.Host, mc.Options{
+		PathPrefix:          m.opts.PathPrefix,
+		ControlPlaneSegment: m.opts.ControlPlaneSegment,
+	}, clusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -122,29 +125,6 @@ func allSynced(m map[reflect.Type]bool) bool {
 		}
 	}
 	return true
-}
-
-func withClusterPrefix(host, pathPrefix, clusterID, controlPlaneSegment string) (string, error) {
-	u, err := url.Parse(host)
-	if err != nil {
-		return "", err
-	}
-	pp := pathPrefix
-	if pp == "" {
-		pp = "/clusters/"
-	}
-	seg := controlPlaneSegment
-	if seg == "" {
-		seg = "control-plane"
-	}
-	// ensure pp ends with "/"
-	if !strings.HasSuffix(pp, "/") {
-		pp = pp + "/"
-	}
-	// join onto existing path
-	basePath := strings.TrimRight(u.Path, "/")
-	u.Path = basePath + pp + clusterID + "/" + seg
-	return u.String(), nil
 }
 
 // StopCluster is test-oriented cleanup; production can leave informers running.

--- a/pkg/multicluster/auth/dispatcher.go
+++ b/pkg/multicluster/auth/dispatcher.go
@@ -1,0 +1,128 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+
+	mc "github.com/kplane-dev/apiserver/pkg/multicluster"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+// ClusterAuthResolver provides per-cluster auth components.
+type ClusterAuthResolver interface {
+	AuthenticatorForCluster(clusterID string) (authenticator.Request, error)
+	AuthorizerForCluster(clusterID string) (authorizer.Authorizer, authorizer.RuleResolver, error)
+}
+
+// ClusterAuthenticator dispatches authentication per cluster.
+type ClusterAuthenticator struct {
+	rootCluster string
+	root        authenticator.Request
+	resolver    ClusterAuthResolver
+}
+
+// NewClusterAuthenticator creates a cluster-aware authenticator.
+func NewClusterAuthenticator(rootCluster string, root authenticator.Request, resolver ClusterAuthResolver) *ClusterAuthenticator {
+	if rootCluster == "" {
+		rootCluster = mc.DefaultClusterName
+	}
+	return &ClusterAuthenticator{
+		rootCluster: rootCluster,
+		root:        root,
+		resolver:    resolver,
+	}
+}
+
+// AuthenticateRequest dispatches by cluster context.
+func (c *ClusterAuthenticator) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	if req == nil {
+		return nil, false, nil
+	}
+	cid := clusterFromContext(req.Context())
+	useRoot := cid == "" || cid == c.rootCluster
+	if useRoot && c.root != nil {
+		return c.root.AuthenticateRequest(req)
+	}
+	if c.resolver == nil {
+		return nil, false, nil
+	}
+	authn, err := c.resolver.AuthenticatorForCluster(cid)
+	if err != nil {
+		return nil, false, err
+	}
+	if authn == nil {
+		return nil, false, nil
+	}
+	return authn.AuthenticateRequest(req)
+}
+
+// ClusterAuthorizer dispatches authorization per cluster.
+type ClusterAuthorizer struct {
+	rootCluster  string
+	root         authorizer.Authorizer
+	rootResolver authorizer.RuleResolver
+	resolver     ClusterAuthResolver
+}
+
+// NewClusterAuthorizer creates a cluster-aware authorizer + rule resolver.
+func NewClusterAuthorizer(rootCluster string, root authorizer.Authorizer, rootResolver authorizer.RuleResolver, resolver ClusterAuthResolver) *ClusterAuthorizer {
+	if rootCluster == "" {
+		rootCluster = mc.DefaultClusterName
+	}
+	if rootResolver == nil {
+		if rr, ok := root.(authorizer.RuleResolver); ok {
+			rootResolver = rr
+		}
+	}
+	return &ClusterAuthorizer{
+		rootCluster:  rootCluster,
+		root:         root,
+		rootResolver: rootResolver,
+		resolver:     resolver,
+	}
+}
+
+// Authorize dispatches by cluster context.
+func (c *ClusterAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+	cid := clusterFromContext(ctx)
+	if cid == "" || (cid == c.rootCluster && c.root != nil) || c.resolver == nil {
+		if c.root == nil {
+			return authorizer.DecisionNoOpinion, "no root authorizer", nil
+		}
+		return c.root.Authorize(ctx, a)
+	}
+	authz, _, err := c.resolver.AuthorizerForCluster(cid)
+	if err != nil {
+		return authorizer.DecisionNoOpinion, "", err
+	}
+	if authz == nil {
+		return authorizer.DecisionNoOpinion, "no cluster authorizer", nil
+	}
+	return authz.Authorize(ctx, a)
+}
+
+// RulesFor dispatches rule resolution per cluster.
+func (c *ClusterAuthorizer) RulesFor(ctx context.Context, u user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
+	cid := clusterFromContext(ctx)
+	if cid == "" || (cid == c.rootCluster && c.rootResolver != nil) || c.resolver == nil {
+		if c.rootResolver == nil {
+			return nil, nil, false, nil
+		}
+		return c.rootResolver.RulesFor(ctx, u, namespace)
+	}
+	_, resolver, err := c.resolver.AuthorizerForCluster(cid)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if resolver == nil {
+		return nil, nil, false, nil
+	}
+	return resolver.RulesFor(ctx, u, namespace)
+}
+
+func clusterFromContext(ctx context.Context) string {
+	cid, _, _ := mc.FromContext(ctx)
+	return cid
+}

--- a/pkg/multicluster/auth/dispatcher_test.go
+++ b/pkg/multicluster/auth/dispatcher_test.go
@@ -1,0 +1,133 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mc "github.com/kplane-dev/apiserver/pkg/multicluster"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+type fakeAuthenticator struct {
+	name   string
+	called *string
+}
+
+func (f *fakeAuthenticator) AuthenticateRequest(*http.Request) (*authenticator.Response, bool, error) {
+	if f.called != nil {
+		*f.called = f.name
+	}
+	return &authenticator.Response{User: &user.DefaultInfo{Name: f.name}}, true, nil
+}
+
+type fakeAuthorizer struct {
+	name   string
+	called *string
+}
+
+func (f *fakeAuthorizer) Authorize(ctx context.Context, _ authorizer.Attributes) (authorizer.Decision, string, error) {
+	if f.called != nil {
+		*f.called = f.name
+	}
+	return authorizer.DecisionAllow, f.name, nil
+}
+
+func (f *fakeAuthorizer) RulesFor(ctx context.Context, _ user.Info, _ string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
+	if f.called != nil {
+		*f.called = f.name
+	}
+	return nil, nil, false, nil
+}
+
+type fakeResolver struct {
+	authn        authenticator.Request
+	authz        authorizer.Authorizer
+	ruleResolver authorizer.RuleResolver
+	lastCluster  *string
+}
+
+func (f *fakeResolver) AuthenticatorForCluster(clusterID string) (authenticator.Request, error) {
+	if f.lastCluster != nil {
+		*f.lastCluster = clusterID
+	}
+	return f.authn, nil
+}
+
+func (f *fakeResolver) AuthorizerForCluster(clusterID string) (authorizer.Authorizer, authorizer.RuleResolver, error) {
+	if f.lastCluster != nil {
+		*f.lastCluster = clusterID
+	}
+	return f.authz, f.ruleResolver, nil
+}
+
+func TestClusterAuthenticatorDispatch(t *testing.T) {
+	var called string
+	var lastCluster string
+
+	root := &fakeAuthenticator{name: "root", called: &called}
+	cluster := &fakeAuthenticator{name: "cluster", called: &called}
+	resolver := &fakeResolver{authn: cluster, lastCluster: &lastCluster}
+
+	dispatch := NewClusterAuthenticator("root", root, resolver)
+
+	req := httptest.NewRequest("GET", "http://example", nil)
+	req = req.WithContext(mc.WithCluster(req.Context(), "root", false))
+	_, _, _ = dispatch.AuthenticateRequest(req)
+	if called != "root" {
+		t.Fatalf("expected root authenticator, got %q", called)
+	}
+
+	called = ""
+	lastCluster = ""
+	req = req.WithContext(mc.WithCluster(req.Context(), "c-1", false))
+	_, _, _ = dispatch.AuthenticateRequest(req)
+	if called != "cluster" {
+		t.Fatalf("expected cluster authenticator, got %q", called)
+	}
+	if lastCluster != "c-1" {
+		t.Fatalf("expected resolver to see cluster c-1, got %q", lastCluster)
+	}
+}
+
+func TestClusterAuthorizerDispatch(t *testing.T) {
+	var called string
+	var lastCluster string
+
+	root := &fakeAuthorizer{name: "root", called: &called}
+	cluster := &fakeAuthorizer{name: "cluster", called: &called}
+	resolver := &fakeResolver{authz: cluster, ruleResolver: cluster, lastCluster: &lastCluster}
+
+	dispatch := NewClusterAuthorizer("root", root, root, resolver)
+
+	ctx := mc.WithCluster(context.Background(), "root", false)
+	_, _, _ = dispatch.Authorize(ctx, authorizer.AttributesRecord{})
+	if called != "root" {
+		t.Fatalf("expected root authorizer, got %q", called)
+	}
+
+	called = ""
+	lastCluster = ""
+	ctx = mc.WithCluster(context.Background(), "c-2", false)
+	_, _, _ = dispatch.Authorize(ctx, authorizer.AttributesRecord{})
+	if called != "cluster" {
+		t.Fatalf("expected cluster authorizer, got %q", called)
+	}
+	if lastCluster != "c-2" {
+		t.Fatalf("expected resolver to see cluster c-2, got %q", lastCluster)
+	}
+
+	called = ""
+	lastCluster = ""
+	ctx = mc.WithCluster(context.Background(), "c-3", false)
+	_, _, _, _ = dispatch.RulesFor(ctx, &user.DefaultInfo{Name: "test"}, "")
+	if called != "cluster" {
+		t.Fatalf("expected cluster rule resolver, got %q", called)
+	}
+	if lastCluster != "c-3" {
+		t.Fatalf("expected resolver to see cluster c-3, got %q", lastCluster)
+	}
+}

--- a/pkg/multicluster/auth/manager.go
+++ b/pkg/multicluster/auth/manager.go
@@ -1,0 +1,238 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	mc "github.com/kplane-dev/apiserver/pkg/multicluster"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/server/egressselector"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	clientgoinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubernetes/pkg/controller/serviceaccount"
+	"k8s.io/kubernetes/pkg/features"
+	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
+	"k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap"
+)
+
+// Options configures per-cluster auth construction.
+type Options struct {
+	BaseLoopbackClientConfig *rest.Config
+	PathPrefix               string
+	ControlPlaneSegment      string
+	Authentication           *kubeoptions.BuiltInAuthenticationOptions
+	Authorization            *kubeoptions.BuiltInAuthorizationOptions
+	EgressSelector           *egressselector.EgressSelector
+	APIServerID              string
+}
+
+// Manager builds per-cluster authenticators and authorizers on demand.
+type Manager struct {
+	ctx  context.Context
+	opts Options
+
+	mu       sync.Mutex
+	clusters map[string]*clusterEnv
+}
+
+type clusterEnv struct {
+	cid string
+
+	stopOnce sync.Once
+	stopCh   chan struct{}
+
+	clientset kubernetes.Interface
+	informers clientgoinformers.SharedInformerFactory
+
+	authenticator authenticator.Request
+	authorizer    authorizer.Authorizer
+	ruleResolver  authorizer.RuleResolver
+}
+
+// NewManager constructs a per-cluster auth manager.
+func NewManager(ctx context.Context, opts Options) *Manager {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return &Manager{
+		ctx:      ctx,
+		opts:     opts,
+		clusters: map[string]*clusterEnv{},
+	}
+}
+
+// AuthenticatorForCluster returns the authenticator for a cluster.
+func (m *Manager) AuthenticatorForCluster(clusterID string) (authenticator.Request, error) {
+	env, err := m.envForCluster(clusterID)
+	if err != nil {
+		return nil, err
+	}
+	return env.authenticator, nil
+}
+
+// AuthorizerForCluster returns the authorizer + rule resolver for a cluster.
+func (m *Manager) AuthorizerForCluster(clusterID string) (authorizer.Authorizer, authorizer.RuleResolver, error) {
+	env, err := m.envForCluster(clusterID)
+	if err != nil {
+		return nil, nil, err
+	}
+	return env.authorizer, env.ruleResolver, nil
+}
+
+// StopCluster shuts down per-cluster informers (test helper).
+func (m *Manager) StopCluster(clusterID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	env, ok := m.clusters[clusterID]
+	if !ok {
+		return
+	}
+	env.stop()
+	delete(m.clusters, clusterID)
+}
+
+func (e *clusterEnv) stop() {
+	e.stopOnce.Do(func() {
+		close(e.stopCh)
+	})
+}
+
+func (m *Manager) envForCluster(clusterID string) (*clusterEnv, error) {
+	m.mu.Lock()
+	if env, ok := m.clusters[clusterID]; ok {
+		m.mu.Unlock()
+		return env, nil
+	}
+
+	if m.opts.BaseLoopbackClientConfig == nil {
+		m.mu.Unlock()
+		return nil, fmt.Errorf("loopback client config is required for cluster auth")
+	}
+
+	cfg := rest.CopyConfig(m.opts.BaseLoopbackClientConfig)
+	host, err := mc.ClusterHost(cfg.Host, mc.Options{
+		PathPrefix:          m.opts.PathPrefix,
+		ControlPlaneSegment: m.opts.ControlPlaneSegment,
+	}, clusterID)
+	if err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+	cfg.Host = host
+
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+	informers := clientgoinformers.NewSharedInformerFactory(cs, 0)
+
+	authn, err := buildAuthenticator(m.ctx, m.opts, cs, informers)
+	if err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+	authz, resolver, err := buildAuthorizer(m.ctx, m.opts, informers)
+	if err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+
+	env := &clusterEnv{
+		cid:           clusterID,
+		stopCh:        make(chan struct{}),
+		clientset:     cs,
+		informers:     informers,
+		authenticator: authn,
+		authorizer:    authz,
+		ruleResolver:  resolver,
+	}
+	informers.Start(env.stopCh)
+
+	if done := m.ctx.Done(); done != nil {
+		go func() {
+			<-done
+			env.stop()
+		}()
+	}
+
+	m.clusters[clusterID] = env
+	m.mu.Unlock()
+	return env, nil
+}
+
+func buildAuthenticator(ctx context.Context, opts Options, clientset kubernetes.Interface, informers clientgoinformers.SharedInformerFactory) (authenticator.Request, error) {
+	if opts.Authentication == nil {
+		return nil, nil
+	}
+	authConfig, err := opts.Authentication.ToAuthenticationConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Authentication.ServiceAccounts != nil && opts.Authentication.ServiceAccounts.OptionalTokenGetter != nil {
+		authConfig.ServiceAccountTokenGetter = opts.Authentication.ServiceAccounts.OptionalTokenGetter(informers)
+	} else {
+		var nodeLister v1.NodeLister
+		if utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountTokenNodeBindingValidation) {
+			nodeLister = informers.Core().V1().Nodes().Lister()
+		}
+
+		authConfig.ServiceAccountTokenGetter = serviceaccount.NewGetterFromClient(
+			clientset,
+			informers.Core().V1().Secrets().Lister(),
+			informers.Core().V1().ServiceAccounts().Lister(),
+			informers.Core().V1().Pods().Lister(),
+			nodeLister,
+		)
+	}
+	authConfig.SecretsWriter = clientset.CoreV1()
+
+	if authConfig.BootstrapToken {
+		authConfig.BootstrapTokenAuthenticator = bootstrap.NewTokenAuthenticator(
+			informers.Core().V1().Secrets().Lister().Secrets(metav1.NamespaceSystem),
+		)
+	}
+
+	if opts.EgressSelector != nil {
+		egressDialer, err := opts.EgressSelector.Lookup(egressselector.ControlPlane.AsNetworkContext())
+		if err != nil {
+			return nil, err
+		}
+		authConfig.CustomDial = egressDialer
+		authConfig.EgressLookup = opts.EgressSelector.Lookup
+	}
+
+	authenticator, _, _, _, err := authConfig.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return authenticator, nil
+}
+
+func buildAuthorizer(ctx context.Context, opts Options, informers clientgoinformers.SharedInformerFactory) (authorizer.Authorizer, authorizer.RuleResolver, error) {
+	if opts.Authorization == nil {
+		return nil, nil, nil
+	}
+	authzConfig, err := opts.Authorization.ToAuthorizationConfig(informers)
+	if err != nil {
+		return nil, nil, err
+	}
+	if authzConfig == nil {
+		return nil, nil, nil
+	}
+	if opts.EgressSelector != nil {
+		egressDialer, err := opts.EgressSelector.Lookup(egressselector.ControlPlane.AsNetworkContext())
+		if err != nil {
+			return nil, nil, err
+		}
+		authzConfig.CustomDial = egressDialer
+	}
+	return authzConfig.New(ctx, opts.APIServerID)
+}

--- a/pkg/multicluster/host.go
+++ b/pkg/multicluster/host.go
@@ -1,0 +1,34 @@
+package multicluster
+
+import (
+	"net/url"
+	"strings"
+)
+
+// ClusterHost returns a copy of host with the cluster path prefix appended.
+func ClusterHost(host string, opts Options, clusterID string) (string, error) {
+	return withClusterPrefix(host, opts.PathPrefix, clusterID, opts.ControlPlaneSegment)
+}
+
+func withClusterPrefix(host, pathPrefix, clusterID, controlPlaneSegment string) (string, error) {
+	u, err := url.Parse(host)
+	if err != nil {
+		return "", err
+	}
+	pp := pathPrefix
+	if pp == "" {
+		pp = DefaultPathPrefix
+	}
+	seg := controlPlaneSegment
+	if seg == "" {
+		seg = DefaultControlPlaneSegment
+	}
+	// ensure pp ends with "/"
+	if !strings.HasSuffix(pp, "/") {
+		pp = pp + "/"
+	}
+	// join onto existing path
+	basePath := strings.TrimRight(u.Path, "/")
+	u.Path = basePath + pp + clusterID + "/" + seg
+	return u.String(), nil
+}

--- a/pkg/multicluster/options.go
+++ b/pkg/multicluster/options.go
@@ -180,6 +180,9 @@ type PerClusterWatch struct{}
 func (PerClusterWatch) WatchPrefixes(ctx context.Context, layout KeyLayout, gr GroupResource) ([]string, error) {
 	cid, _, _ := FromContext(ctx)
 	if cid == "" {
+		cid = layout.Options.DefaultCluster
+	}
+	if cid == "" {
 		cid = DefaultClusterName
 	}
 	return []string{layout.PerClusterRoot(cid, gr)}, nil

--- a/test/smoke/apiserver_test.go
+++ b/test/smoke/apiserver_test.go
@@ -21,6 +21,10 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	mc "github.com/kplane-dev/apiserver/pkg/multicluster"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type testAPIServer struct {
@@ -28,6 +32,7 @@ type testAPIServer struct {
 	binPath string
 	port    int
 	tmpDir  string
+	root    string
 
 	cmd    *exec.Cmd
 	cancel context.CancelFunc
@@ -106,7 +111,16 @@ func mustWriteTokenFile(t *testing.T, path string) string {
 	return path
 }
 
+type apiserverOptions struct {
+	rootCluster string
+	extraArgs   []string
+}
+
 func startAPIServer(t *testing.T, etcdEndpoints string) *testAPIServer {
+	return startAPIServerWithOptions(t, etcdEndpoints, apiserverOptions{})
+}
+
+func startAPIServerWithOptions(t *testing.T, etcdEndpoints string, opts apiserverOptions) *testAPIServer {
 	t.Helper()
 	if strings.TrimSpace(etcdEndpoints) == "" {
 		t.Skip("ETCD_ENDPOINTS is not set; skipping integration smoke tests")
@@ -124,6 +138,10 @@ func startAPIServer(t *testing.T, etcdEndpoints string) *testAPIServer {
 		tmpDir:  tmp,
 		cancel:  cancel,
 	}
+	if opts.rootCluster == "" {
+		opts.rootCluster = mc.DefaultClusterName
+	}
+	s.root = opts.rootCluster
 
 	args := []string{
 		"--etcd-servers=" + etcdEndpoints,
@@ -140,6 +158,12 @@ func startAPIServer(t *testing.T, etcdEndpoints string) *testAPIServer {
 		"--service-account-key-file=" + filepath.Join(tmp, "sa.key"),
 		// reduce noise + make startup faster for tests
 		"--v=2",
+	}
+	if opts.rootCluster != mc.DefaultClusterName {
+		args = append(args, "--root-control-plane-name="+opts.rootCluster)
+	}
+	if len(opts.extraArgs) > 0 {
+		args = append(args, opts.extraArgs...)
 	}
 
 	cmd := exec.CommandContext(ctx, bin, args...)
@@ -162,7 +186,7 @@ func startAPIServer(t *testing.T, etcdEndpoints string) *testAPIServer {
 	})
 
 	// Wait for readiness on root cluster
-	s.waitReady(t, "root")
+	s.waitReady(t, s.root)
 
 	return s
 }
@@ -265,4 +289,22 @@ func isConnRefused(err error) bool {
 		return true
 	}
 	return strings.Contains(err.Error(), "connection refused")
+}
+
+func TestRootControlPlaneNameOverride(t *testing.T) {
+	etcd := os.Getenv("ETCD_ENDPOINTS")
+	s := startAPIServerWithOptions(t, etcd, apiserverOptions{rootCluster: "default"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	cs := kubeClientForCluster(t, s, s.root)
+	cmName := "cm-" + randSuffix(4)
+	_, err := cs.CoreV1().ConfigMaps("default").Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cmName},
+		Data:       map[string]string{"root": "ok"},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create configmap in root cluster %q: %v", s.root, err)
+	}
 }

--- a/test/smoke/auth_test.go
+++ b/test/smoke/auth_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 	"time"
 
+	authenticationv1 "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -82,6 +84,46 @@ func TestRBACIsolationAcrossClusters(t *testing.T) {
 	waitForSubjectAccessReview(ctx, t, csRoot, sar, false)
 }
 
+func TestServiceAccountTokenIsolationAcrossClusters(t *testing.T) {
+	etcd := os.Getenv("ETCD_ENDPOINTS")
+	s := startAPIServer(t, etcd)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	clusterA := "c-" + randSuffix(3)
+	root := s.root
+
+	csRoot := kubeClientForCluster(t, s, root)
+	csA := kubeClientForCluster(t, s, clusterA)
+
+	ns := "default"
+	saRoot := "sa-" + randSuffix(3)
+	saA := "sa-" + randSuffix(3)
+
+	_, err := csRoot.CoreV1().ServiceAccounts(ns).Create(ctx, &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: saRoot},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("cluster=%s create serviceaccount: %v", root, err)
+	}
+
+	_, err = csA.CoreV1().ServiceAccounts(ns).Create(ctx, &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: saA},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("cluster=%s create serviceaccount: %v", clusterA, err)
+	}
+
+	tokenRoot := requestServiceAccountToken(ctx, t, csRoot, ns, saRoot)
+	tokenA := requestServiceAccountToken(ctx, t, csA, ns, saA)
+
+	waitForTokenReview(ctx, t, csRoot, tokenRoot, true)
+	waitForTokenReview(ctx, t, csA, tokenA, true)
+	waitForTokenReview(ctx, t, csRoot, tokenA, false)
+	waitForTokenReview(ctx, t, csA, tokenRoot, false)
+}
+
 func waitForSubjectAccessReview(ctx context.Context, t *testing.T, cs kubernetes.Interface, sar *authorizationv1.SubjectAccessReview, wantAllowed bool) {
 	t.Helper()
 
@@ -104,4 +146,44 @@ func waitForSubjectAccessReview(ctx context.Context, t *testing.T, cs kubernetes
 		time.Sleep(500 * time.Millisecond)
 	}
 	t.Fatalf("expected SAR allowed=%v, last error: %v", wantAllowed, lastErr)
+}
+
+func requestServiceAccountToken(ctx context.Context, t *testing.T, cs kubernetes.Interface, namespace, name string) string {
+	t.Helper()
+	resp, err := cs.CoreV1().ServiceAccounts(namespace).CreateToken(ctx, name, &authenticationv1.TokenRequest{
+		Spec: authenticationv1.TokenRequestSpec{
+			Audiences: []string{"https://kubernetes.default.svc"},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create token for serviceaccount %s/%s: %v", namespace, name, err)
+	}
+	if resp == nil || resp.Status.Token == "" {
+		t.Fatalf("empty token for serviceaccount %s/%s", namespace, name)
+	}
+	return resp.Status.Token
+}
+
+func waitForTokenReview(ctx context.Context, t *testing.T, cs kubernetes.Interface, token string, wantAuthenticated bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(30 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := cs.AuthenticationV1().TokenReviews().Create(ctx, &authenticationv1.TokenReview{
+			Spec: authenticationv1.TokenReviewSpec{
+				Token: token,
+			},
+		}, metav1.CreateOptions{})
+		if err == nil {
+			if resp.Status.Authenticated == wantAuthenticated {
+				return
+			}
+			lastErr = fmt.Errorf("authenticated=%v error=%q", resp.Status.Authenticated, resp.Status.Error)
+		} else {
+			lastErr = err
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("expected TokenReview authenticated=%v, last error: %v", wantAuthenticated, lastErr)
 }

--- a/test/smoke/auth_test.go
+++ b/test/smoke/auth_test.go
@@ -1,0 +1,107 @@
+package smoke
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func TestRBACIsolationAcrossClusters(t *testing.T) {
+	etcd := os.Getenv("ETCD_ENDPOINTS")
+	s := startAPIServer(t, etcd)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	clusterA := "c-" + randSuffix(3)
+	root := s.root
+
+	csRoot := kubeClientForCluster(t, s, root)
+	csA := kubeClientForCluster(t, s, clusterA)
+
+	roleName := "role-" + randSuffix(4)
+	bindingName := "rb-" + randSuffix(4)
+	subjectUser := "user-" + randSuffix(4)
+
+	_, err := csA.RbacV1().ClusterRoles().Create(ctx, &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: roleName},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"configmaps"},
+				Verbs:     []string{"get", "list"},
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("cluster=%s create clusterrole: %v", clusterA, err)
+	}
+	t.Cleanup(func() {
+		_ = csA.RbacV1().ClusterRoles().Delete(context.Background(), roleName, metav1.DeleteOptions{})
+	})
+
+	_, err = csA.RbacV1().ClusterRoleBindings().Create(ctx, &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: bindingName},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.UserKind, Name: subjectUser},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     roleName,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("cluster=%s create clusterrolebinding: %v", clusterA, err)
+	}
+	t.Cleanup(func() {
+		_ = csA.RbacV1().ClusterRoleBindings().Delete(context.Background(), bindingName, metav1.DeleteOptions{})
+	})
+
+	sar := &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			User: subjectUser,
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: "default",
+				Verb:      "get",
+				Group:     "",
+				Resource:  "configmaps",
+			},
+		},
+	}
+
+	waitForSubjectAccessReview(ctx, t, csA, sar, true)
+	waitForSubjectAccessReview(ctx, t, csRoot, sar, false)
+}
+
+func waitForSubjectAccessReview(ctx context.Context, t *testing.T, cs kubernetes.Interface, sar *authorizationv1.SubjectAccessReview, wantAllowed bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(30 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := cs.AuthorizationV1().SubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
+		if err == nil {
+			if resp.Status.Allowed == wantAllowed {
+				return
+			}
+			lastErr = fmt.Errorf("allowed=%v reason=%s", resp.Status.Allowed, resp.Status.Reason)
+		} else {
+			if errors.IsForbidden(err) || errors.IsUnauthorized(err) {
+				lastErr = err
+			} else {
+				lastErr = err
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("expected SAR allowed=%v, last error: %v", wantAllowed, lastErr)
+}

--- a/test/smoke/crud_test.go
+++ b/test/smoke/crud_test.go
@@ -28,7 +28,7 @@ func TestCRUD_RandomizedAcrossClusters(t *testing.T) {
 	defer cancel()
 
 	clusters := []string{
-		"root",
+		s.root,
 		"c-" + randSuffix(3),
 		"c-" + randSuffix(3),
 	}

--- a/test/smoke/webhook_test.go
+++ b/test/smoke/webhook_test.go
@@ -157,7 +157,7 @@ func TestWebhook_ServiceBacked_MulticlusterScoping(t *testing.T) {
 	// Pick a non-root cluster to validate the suspected bug.
 	clusterA := "c-" + randSuffix(3)
 	clusterB := "c-" + randSuffix(3)
-	root := "root"
+	root := s.root
 
 	csA := kubeClientForCluster(t, s, clusterA)
 	csB := kubeClientForCluster(t, s, clusterB)


### PR DESCRIPTION
Adds a configurable root control plane name flag and implements cluster-aware authentication and authorization for multi-cluster isolation.

---
<a href="https://cursor.com/background-agent?bcId=bc-2758ef68-784d-4209-ba8b-e4ab8cd1604d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2758ef68-784d-4209-ba8b-e4ab8cd1604d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

