### PR TITLE
Cluster-aware namespace lifecycle admission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ go.work.sum
 
 # env file
 .env
+.dev
 
 # Editor/IDE
 # .idea/

--- a/cmd/apiserver/app/config.go
+++ b/cmd/apiserver/app/config.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/admission"
+	namespaceplugin "k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle"
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/util/webhook"
 	aggregatorapiserver "k8s.io/kube-aggregator/pkg/apiserver"
@@ -36,6 +37,7 @@ import (
 	"github.com/kplane-dev/apiserver/cmd/apiserver/app/options"
 	mc "github.com/kplane-dev/apiserver/pkg/multicluster"
 	mca "github.com/kplane-dev/apiserver/pkg/multicluster/admission"
+	mcnsl "github.com/kplane-dev/apiserver/pkg/multicluster/admission/namespace"
 	mcwh "github.com/kplane-dev/apiserver/pkg/multicluster/admission/webhook"
 	mcauth "github.com/kplane-dev/apiserver/pkg/multicluster/auth"
 )
@@ -92,6 +94,7 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 			opts.Admission.GenericAdmission.DisablePlugins,
 			"MutatingAdmissionWebhook",
 			"ValidatingAdmissionWebhook",
+			namespaceplugin.PluginName,
 		)
 	}
 
@@ -139,12 +142,20 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 		genericConfig.RESTOptionsGetter = mc.RESTOptionsDecorator{Delegate: genericConfig.RESTOptionsGetter, Options: mcOpts}
 	}
 
-	// Wrap admission: mutating first, then existing chain, then validating
+	// Cluster-aware namespace lifecycle (per-cluster client + informer).
+	mcNamespaceMgr := mcnsl.NewManager(mcnsl.Options{
+		BaseLoopbackClientConfig: genericConfig.LoopbackClientConfig,
+		PathPrefix:               mcOpts.PathPrefix,
+		ControlPlaneSegment:      mcOpts.ControlPlaneSegment,
+	})
+	mcNamespaceLifecycle := mcnsl.NewLifecycle(mcOpts, mcNamespaceMgr)
+
+	// Wrap admission: mutating first, namespace lifecycle, then existing chain, then validating
 	{
 		mut := mca.NewMutating(mcOpts)
 		val := mca.NewValidating(mcOpts)
 		base := genericConfig.AdmissionControl
-		chain := []admission.Interface{mut}
+		chain := []admission.Interface{mut, mcNamespaceLifecycle}
 		if base != nil {
 			chain = append(chain, base)
 		}
@@ -181,7 +192,7 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 		mut := mca.NewMutating(mcOpts)
 		val := mca.NewValidating(mcOpts)
 		base := c.KubeAPIs.ControlPlane.Generic.AdmissionControl
-		chain := []admission.Interface{mut, mcMutatingWebhook}
+		chain := []admission.Interface{mut, mcNamespaceLifecycle, mcMutatingWebhook}
 		if base != nil {
 			chain = append(chain, base)
 		}
@@ -204,7 +215,7 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 		mut := mca.NewMutating(mcOpts)
 		val := mca.NewValidating(mcOpts)
 		base := apiExtensions.GenericConfig.AdmissionControl
-		chain := []admission.Interface{mut, mcMutatingWebhook}
+		chain := []admission.Interface{mut, mcNamespaceLifecycle, mcMutatingWebhook}
 		if base != nil {
 			chain = append(chain, base)
 		}
@@ -227,7 +238,7 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 		mut := mca.NewMutating(mcOpts)
 		val := mca.NewValidating(mcOpts)
 		base := aggregator.GenericConfig.AdmissionControl
-		chain := []admission.Interface{mut, mcMutatingWebhook}
+		chain := []admission.Interface{mut, mcNamespaceLifecycle, mcMutatingWebhook}
 		if base != nil {
 			chain = append(chain, base)
 		}

--- a/pkg/multicluster/admission/namespace/manager.go
+++ b/pkg/multicluster/admission/namespace/manager.go
@@ -1,0 +1,82 @@
+package namespace
+
+import (
+	"sync"
+
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	mc "github.com/kplane-dev/apiserver/pkg/multicluster"
+)
+
+type Options struct {
+	// BaseLoopbackClientConfig is the apiserver loopback config for the root server.
+	// We clone it and rewrite Host to include the cluster path prefix.
+	BaseLoopbackClientConfig *rest.Config
+
+	// PathPrefix and ControlPlaneSegment define the cluster URL form.
+	PathPrefix          string
+	ControlPlaneSegment string
+}
+
+type Manager struct {
+	opts Options
+
+	mu       sync.Mutex
+	clusters map[string]*clusterEnv
+}
+
+type clusterEnv struct {
+	stopCh chan struct{}
+	cid    string
+
+	clientset kubernetes.Interface
+	informers informers.SharedInformerFactory
+}
+
+func NewManager(opts Options) *Manager {
+	return &Manager{
+		opts:     opts,
+		clusters: map[string]*clusterEnv{},
+	}
+}
+
+func (m *Manager) envForCluster(clusterID string) (*clusterEnv, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if e, ok := m.clusters[clusterID]; ok {
+		return e, nil
+	}
+
+	cfg := rest.CopyConfig(m.opts.BaseLoopbackClientConfig)
+	host, err := mc.ClusterHost(cfg.Host, mc.Options{
+		PathPrefix:          m.opts.PathPrefix,
+		ControlPlaneSegment: m.opts.ControlPlaneSegment,
+	}, clusterID)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Host = host
+
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	inf := informers.NewSharedInformerFactory(cs, 0)
+
+	e := &clusterEnv{
+		cid:       clusterID,
+		stopCh:    make(chan struct{}),
+		clientset: cs,
+		informers: inf,
+	}
+
+	// Warm the namespaces informer (used by NamespaceLifecycle).
+	_ = inf.Core().V1().Namespaces().Informer()
+	inf.Start(e.stopCh)
+
+	m.clusters[clusterID] = e
+	return e, nil
+}

--- a/pkg/multicluster/admission/namespace/plugins.go
+++ b/pkg/multicluster/admission/namespace/plugins.go
@@ -1,0 +1,78 @@
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	mc "github.com/kplane-dev/apiserver/pkg/multicluster"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/admission"
+	upstream "k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle"
+)
+
+// LifecyclePlugin dispatches NamespaceLifecycle per cluster.
+type LifecyclePlugin struct {
+	*admission.Handler
+	opts mc.Options
+	mgr  *Manager
+
+	mu    sync.Mutex
+	cache map[string]*upstream.Lifecycle
+}
+
+func NewLifecycle(opts mc.Options, mgr *Manager) *LifecyclePlugin {
+	return &LifecyclePlugin{
+		Handler: admission.NewHandler(admission.Create, admission.Update, admission.Delete),
+		opts:    opts,
+		mgr:     mgr,
+		cache:   map[string]*upstream.Lifecycle{},
+	}
+}
+
+func (p *LifecyclePlugin) Admit(ctx context.Context, attr admission.Attributes, o admission.ObjectInterfaces) error {
+	return p.forCluster(ctx).Admit(ctx, attr, o)
+}
+
+func (p *LifecyclePlugin) ValidateInitialization() error {
+	if p.mgr == nil {
+		return fmt.Errorf("missing manager")
+	}
+	return nil
+}
+
+func (p *LifecyclePlugin) forCluster(ctx context.Context) *upstream.Lifecycle {
+	cid, _, _ := mc.FromContext(ctx)
+	if cid == "" {
+		cid = p.opts.DefaultCluster
+	}
+	if cid == "" {
+		cid = mc.DefaultClusterName
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if existing, ok := p.cache[cid]; ok {
+		return existing
+	}
+
+	env, err := p.mgr.envForCluster(cid)
+	if err != nil {
+		panic(err)
+	}
+
+	plugin, err := upstream.NewLifecycle(sets.NewString(metav1.NamespaceDefault, metav1.NamespaceSystem, metav1.NamespacePublic))
+	if err != nil {
+		panic(err)
+	}
+	plugin.SetExternalKubeClientSet(env.clientset)
+	plugin.SetExternalKubeInformerFactory(env.informers)
+	if err := plugin.ValidateInitialization(); err != nil {
+		panic(err)
+	}
+
+	p.cache[cid] = plugin
+	return plugin
+}

--- a/test/smoke/namespace_lifecycle_test.go
+++ b/test/smoke/namespace_lifecycle_test.go
@@ -1,0 +1,57 @@
+package smoke
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// Ensure NamespaceLifecycle uses cluster-scoped namespace data instead of root cache.
+func TestNamespaceLifecycle_VirtualClusterNamespace(t *testing.T) {
+	etcd := os.Getenv("ETCD_ENDPOINTS")
+	s := startAPIServer(t, etcd)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	clusterA := "c-" + randSuffix(3)
+	csA := kubeClientForCluster(t, s, clusterA)
+	csRoot := kubeClientForCluster(t, s, s.root)
+
+	ns := "ns-" + randSuffix(4)
+	_, err := csA.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: ns},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("cluster=%s create namespace: %v", clusterA, err)
+	}
+
+	// Root should not see virtual cluster namespaces.
+	_, err = csRoot.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{})
+	if err == nil || !apierrors.IsNotFound(err) {
+		t.Fatalf("expected root to not have namespace %q, got: %v", ns, err)
+	}
+
+	saName := "sa-" + randSuffix(4)
+	err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		_, err := csA.CoreV1().ServiceAccounts(ns).Create(ctx, &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: saName},
+		}, metav1.CreateOptions{})
+		if err == nil {
+			return true, nil
+		}
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	})
+	if err != nil {
+		t.Fatalf("cluster=%s create serviceaccount in namespace %q: %v", clusterA, ns, err)
+	}
+}


### PR DESCRIPTION
* replace upstream NamespaceLifecycle with per-cluster wrapper
* wire namespace lifecycle into all admission chains
* add smoke test for virtual cluster namespace lifecycle
* ignore .dev directory